### PR TITLE
Uniformize the response from the flip API

### DIFF
--- a/core.go
+++ b/core.go
@@ -25,22 +25,21 @@ type CoreGateway struct {
 	Client Client
 }
 
-func (gateway *CoreGateway) Call(method, path string, header map[string]string, body io.Reader, v interface{}, x interface{}) error {
+func (gateway *CoreGateway) Call(method, path string, header map[string]string, body io.Reader, v interface{}) (err error, respErr ErrorResponse) {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-
 	path = gateway.Client.BaseURL + path
-
-	return gateway.Client.Call(method, path, header, body, v, x)
-}
-
-func (gateway *CoreGateway) GetCurrentBalance() (resp Balance, err error) {
-	err = gateway.Call("GET", CurrentBalanceURL, nil, nil, &resp, nil)
+	err, respErr = gateway.Client.Call(method, path, header, body, v)
 	return
 }
 
-func (gateway *CoreGateway) GetBanks(bankCode string) (resp []Bank, err error) {
+func (gateway *CoreGateway) GetCurrentBalance() (resp Balance, respError ErrorResponse, err error) {
+	err, respError = gateway.Call("GET", CurrentBalanceURL, nil, nil, &resp)
+	return
+}
+
+func (gateway *CoreGateway) GetBanks(bankCode string) (resp []Bank, respError ErrorResponse, err error) {
 	data := url.Values{}
 	if bankCode != "" {
 		data.Set("code", bankCode)
@@ -50,11 +49,11 @@ func (gateway *CoreGateway) GetBanks(bankCode string) (resp []Bank, err error) {
 		"Content-Type": "application/x-www-form-urlencoded",
 	}
 
-	err = gateway.Call("GET", fmt.Sprintf("%s?%s", BankListURL, data.Encode()), headers, nil, &resp, nil)
+	err, respError = gateway.Call("GET", fmt.Sprintf("%s?%s", BankListURL, data.Encode()), headers, nil, &resp)
 	return
 }
 
-func (gateway *CoreGateway) GetBankAccountInquiry(bankCode string, accountNumber string) (resp BankAccountInquiry, err error) {
+func (gateway *CoreGateway) GetBankAccountInquiry(bankCode string, accountNumber string) (resp BankAccountInquiry, respError ErrorResponse, err error) {
 	data := url.Values{}
 	if bankCode != "" {
 		data.Set("bank_code", bankCode)
@@ -68,21 +67,21 @@ func (gateway *CoreGateway) GetBankAccountInquiry(bankCode string, accountNumber
 		"Content-Type": "application/x-www-form-urlencoded",
 	}
 
-	err = gateway.Call("POST", BankAccountInquiryURL, headers, strings.NewReader(data.Encode()), &resp, nil)
+	err, respError = gateway.Call("POST", BankAccountInquiryURL, headers, strings.NewReader(data.Encode()), &resp)
 	return
 }
 
-func (gateway *CoreGateway) CheckIsMaintenance() (resp CheckIsMaintenance, err error) {
-	err = gateway.Call("GET", CheckIsMaintenanceURL, nil, nil, &resp, nil)
+func (gateway *CoreGateway) CheckIsMaintenance() (resp CheckIsMaintenance, respError ErrorResponse, err error) {
+	err, respError = gateway.Call("GET", CheckIsMaintenanceURL, nil, nil, &resp)
 	return
 }
 
-func (gateway *CoreGateway) CheckIsOperational() (resp CheckIsOperational, err error) {
-	err = gateway.Call("GET", CheckIsOperationalURL, nil, nil, &resp, nil)
+func (gateway *CoreGateway) CheckIsOperational() (resp CheckIsOperational, respError ErrorResponse, err error) {
+	err, respError = gateway.Call("GET", CheckIsOperationalURL, nil, nil, &resp)
 	return
 }
 
-func (gateway *CoreGateway) GetAllDisbursement(perPage int, page int) (resp GetAllDisbursement, err error) {
+func (gateway *CoreGateway) GetAllDisbursement(perPage int, page int) (resp GetAllDisbursement, respError ErrorResponse, err error) {
 	data := url.Values{}
 	strPerPage := strconv.Itoa(perPage)
 	strPage := strconv.Itoa(page)
@@ -90,13 +89,13 @@ func (gateway *CoreGateway) GetAllDisbursement(perPage int, page int) (resp GetA
 	data.Set("page", strPage)
 	data.Set("sort", "-id")
 
-	err = gateway.Call("GET", fmt.Sprintf("%s?%s", GetAllDisbursementURL, data.Encode()), nil, nil, &resp, nil)
+	err, respError = gateway.Call("GET", fmt.Sprintf("%s?%s", GetAllDisbursementURL, data.Encode()), nil, nil, &resp)
 	return
 }
 
 func (gateway *CoreGateway) GetDisbursementInfo(trxId int) (resp Disbursement, respError ErrorResponse, err error) {
 
-	err = gateway.Call("GET", fmt.Sprintf("%s/%d", DisburseURL, trxId), nil, nil, &resp, &respError)
+	err, respError = gateway.Call("GET", fmt.Sprintf("%s/%d", DisburseURL, trxId), nil, nil, &resp)
 	return
 }
 
@@ -104,11 +103,11 @@ func (gateway *CoreGateway) GetDisbursementQueue(trxId int) (resp DisbursementQu
 	strTrxId := strconv.Itoa(trxId)
 	url := strings.Replace(GetDisbursementQueueURL, "[trxId]", strTrxId, -1)
 
-	err = gateway.Call("GET", url, nil, nil, &resp, &respError)
+	err, respError = gateway.Call("GET", url, nil, nil, &resp)
 	return
 }
 
-func (gateway *CoreGateway) Disburse(idempotencyKey string, payload DisbursementRequest) (resp Disbursement, respError DisbursementError, err error) {
+func (gateway *CoreGateway) Disburse(idempotencyKey string, payload DisbursementRequest) (resp Disbursement, respError ErrorResponse, err error) {
 	headers := map[string]string{
 		"Content-Type":    "application/x-www-form-urlencoded",
 		"idempotency-key": idempotencyKey,
@@ -119,6 +118,6 @@ func (gateway *CoreGateway) Disburse(idempotencyKey string, payload Disbursement
 		return
 	}
 
-	err = gateway.Call("POST", DisburseURL, headers, strings.NewReader(params.Encode()), &resp, &respError)
+	err, respError = gateway.Call("POST", DisburseURL, headers, strings.NewReader(params.Encode()), &resp)
 	return
 }

--- a/response.go
+++ b/response.go
@@ -84,9 +84,15 @@ type GetAllDisbursement struct {
 }
 
 type ErrorResponse struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Error   interface{} `json:"error,omitempty"`
+}
+
+type GeneralErrorResponse struct {
 	Name    string `json:"name"`
 	Message string `json:"message"`
-	Code    uint16 `json:"code"`
-	Status  uint16 `json:"status"`
+	Code    int    `json:"code"`
+	Status  int    `json:"status"`
 	Type    string `json:"type"`
 }


### PR DESCRIPTION
Since flip has some different error response, we need to uniformize the response for handling error easier
**Auth Error (Code 401)**
```
{
    "name": "Unauthorized",
    "message": "Your request was made with invalid credentials.",
    "code": 0,
    "status": 401,
    "type": "yii\\web\\UnauthorizedHttpException"
}
```

**Disbursement validation error (Code 422)**
```
{
    "code": "VALIDATION_ERROR",
    "errors": [
        {
            "attribute": "amount",
            "code": 1001,
            "message": "Amount cannot be empty"
        }
    ]
}
```

**Sangu flip response format**
```
{
    "code": "401",
    "message": "Your request was made with invalid credentials.",
    "error": {
                  "name": "Unauthorized",
                  "message": "Your request was made with invalid credentials.",
                  "code": 0,
                  "status": 401,
                  "type": "yii\\web\\UnauthorizedHttpException"
     }
}
```

```
{
    "code": "422",
    "message": "VALIDATION_ERROR",
    "error": {
                  "code": "VALIDATION_ERROR",
                  "errors": [
                                {
                                      "attribute": "amount",
                                      "code": 1001,
                                      "message": "Amount cannot be empty"
                                }
                                ]
                   }
}
```